### PR TITLE
Add labels and annotations to domain and subdomain data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ data "st-domain-management_domain_filter" "example" {
 ```terrraform
 resource "st-domain-management_domain_annotations" "example" {
   for_each = {
-    for index, value in data.st-domain-management_domain_filter.example.domains :
-    value => value
+    for value in tolist(data.st-domain-management_domain_filter.example.domains) :
+    value.domain => value
   }
 
   domain = each.value

--- a/api/model.go
+++ b/api/model.go
@@ -1,0 +1,34 @@
+package api
+
+type Metadata struct {
+	Labels      map[string]interface{} `json:"labels"`
+	Annotations map[string]interface{} `json:"annotations"`
+}
+
+type Subdomain struct {
+	Name     string   `json:"name"`
+	Metadata Metadata `json:"metadata"`
+}
+
+type Domain struct {
+	Domain   string   `json:"domain"`
+	Metadata Metadata `json:"metadata"`
+}
+
+type DomainFull struct {
+	Domain     string       `json:"domain"`
+	Metadata   Metadata     `json:"metadata"`
+	Subdomains []*Subdomain `json:"subdomains"`
+}
+
+type DomainResponse struct {
+	Domains []*Domain `json:"dt"`
+}
+
+type DomainFullResponse struct {
+	DomainsFull []*DomainFull `json:"dt"`
+}
+
+type AnnotationsResponse struct {
+	Domain Domain `json:"dt"`
+}

--- a/docs/data-sources/domain_filter.md
+++ b/docs/data-sources/domain_filter.md
@@ -35,4 +35,13 @@ data "st-domain-management_domain_filter" "example" {
 
 ### Read-Only
 
-- `domains` (Set of String) Set of domain names that match the given filter.
+- `domains` (Attributes Set) Set of domain names that match the given filter. (see [below for nested schema](#nestedatt--domains))
+
+<a id="nestedatt--domains"></a>
+### Nested Schema for `domains`
+
+Read-Only:
+
+- `annotations` (String) The JSON encoded string of the annotations attached to this domain. Wrap this resource in jsondecode() to use it as a Terraform data type.
+- `domain` (String) The name of the domain.
+- `labels` (String) The JSON encoded string of the labels attached to this domain. Wrap this resource in jsondecode() to use it as a Terraform data type.

--- a/docs/data-sources/subdomain_filter.md
+++ b/docs/data-sources/subdomain_filter.md
@@ -47,8 +47,18 @@ data "st-domain-management_subdomain_filter" "example" {
 
 Read-Only:
 
-- `domain` (String) The main domain of this result.
+- `domain` (Attributes) (see [below for nested schema](#nestedatt--domains--domain))
 - `subdomains` (Attributes Set) (see [below for nested schema](#nestedatt--domains--subdomains))
+
+<a id="nestedatt--domains--domain"></a>
+### Nested Schema for `domains.domain`
+
+Read-Only:
+
+- `annotations` (String) The JSON encoded string of the annotations attached to this domain. Wrap this resource in jsondecode() to use it as a Terraform data type.
+- `labels` (String) The JSON encoded string of the labels attached to this domain. Wrap this resource in jsondecode() to use it as a Terraform data type.
+- `name` (String) The name of the domain.
+
 
 <a id="nestedatt--domains--subdomains"></a>
 ### Nested Schema for `domains.subdomains`
@@ -56,5 +66,5 @@ Read-Only:
 Read-Only:
 
 - `fqdn` (String) The result of joining the subdomain name with the main domain.
-- `labels` (String) The JSON encoded string of the labels attachd to this subdomain. Wrap this resource in jsonencode() to use it as a Terraform resource.
+- `labels` (String) The JSON encoded string of the labels attachd to this subdomain. Wrap this resource in jsondecode() to use it as a Terraform data type.
 - `name` (String) The name of subdomain.

--- a/domain_management/data_source_domain_filter.go
+++ b/domain_management/data_source_domain_filter.go
@@ -187,8 +187,8 @@ func domainApiModelToDataSourceModel(httpResp []*api.Domain) (domains []domain, 
 		}
 
 		domains = append(domains, domain{
-			Domain: types.StringValue(domainResp.Domain),
-			Labels: jsontypes.NewNormalizedValue(string(labels)),
+			Domain:      types.StringValue(domainResp.Domain),
+			Labels:      jsontypes.NewNormalizedValue(string(labels)),
 			Annotations: jsontypes.NewNormalizedValue(string(annotations)),
 		})
 	}

--- a/utils/jsondiff_test.go
+++ b/utils/jsondiff_test.go
@@ -178,3 +178,13 @@ func TestPathAdhereToRFC6902(t *testing.T) {
 		assert.Equal("annotationB~1annotationC~/annotationD", k, "")
 	}
 }
+
+func TestDiffingOnEmptyString(t *testing.T) {
+	plan := json.RawMessage("")
+	state := json.RawMessage("")
+
+	_, err := JSONDiffToTerraformOperations(state, plan)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
- Refactor api clients code structure
  - Added `api/models.go` file
  - Api requests return api model instead of raw http responses
- Added labels and annotations to `domains` section in `subdomain_filter` data source.
- Added labels and annotations to `domain` in `domain_filter` data source.
- `Set` data type is used when dealing with array of domains, subdomains 
  - Prevents implicit assumption of ordering
  - Ensures uniqueness, as lists allows for duplicate items